### PR TITLE
Do not trim trailing whitespace in markdown files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This is a common editorconfig setting for JavaScript projects. Trailing whitespace in markdown creates a line break, therefore trailing whitespace should not be trimmed in markdown files.