### PR TITLE
Make .editorconfig configurable.

### DIFF
--- a/sao.js
+++ b/sao.js
@@ -14,6 +14,7 @@ const slug = require('limax');
 const npmConf = require('npm-conf');
 const npmName = require('npm-name');
 const isValidNpmName = require('is-valid-npm-name');
+const { execSync } = require('child_process');
 
 const conf = npmConf();
 
@@ -150,6 +151,13 @@ module.exports = {
     } else {
       ctx.npmInstall();
     }
+
+    execSync(`${ctx.folderPath}/node_modules/.bin/xo . --fix`, {
+      cwd: ctx.folderPath
+    });
+    execSync('npm test', {
+      cwd: ctx.folderPath
+    });
 
     // create `LICENSE` file with license selected
     if (ctx.answers.license !== 'MIT') {

--- a/sao.js
+++ b/sao.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-
+const { execSync } = require('child_process');
 const githubUsernameRegex = require('github-username-regex');
 // const opn = require('opn');
 const isURL = require('is-url');
@@ -14,7 +14,6 @@ const slug = require('limax');
 const npmConf = require('npm-conf');
 const npmName = require('npm-name');
 const isValidNpmName = require('is-valid-npm-name');
-const { execSync } = require('child_process');
 
 const conf = npmConf();
 
@@ -118,7 +117,7 @@ module.exports = {
     trimWhitespaceMarkdown: {
       message: 'Trim trailing whitespace in markdown files',
       type: 'confirm',
-      default: true
+      default: false
     },
     indentation: {
       message: 'Indentation',
@@ -153,10 +152,13 @@ module.exports = {
     }
 
     execSync(`${ctx.folderPath}/node_modules/.bin/xo . --fix`, {
-      cwd: ctx.folderPath
+      cwd: ctx.folderPath,
+      stdio: 'inherit'
     });
-    execSync('npm test', {
-      cwd: ctx.folderPath
+
+    execSync(`${ctx.answers.pm === 'yarn' ? 'yarn' : 'npm'} test`, {
+      cwd: ctx.folderPath,
+      stdio: 'inherit'
     });
 
     // create `LICENSE` file with license selected

--- a/sao.js
+++ b/sao.js
@@ -113,6 +113,17 @@ module.exports = {
           ? true
           : 'Please include a valid GitHub.com URL without a trailing slash';
       }
+    },
+    trimWhitespaceMarkdown: {
+      message: 'Trim trailing whitespace in markdown files?',
+      type: 'confirm',
+      default: true
+    },
+    editorconfigIndentation: {
+      message: 'Indentation',
+      type: 'list',
+      choices: ['2 spaces', '4 spaces', 'tabs'],
+      default: '2 spaces'
     }
   },
   move: {

--- a/sao.js
+++ b/sao.js
@@ -119,7 +119,7 @@ module.exports = {
       type: 'confirm',
       default: true
     },
-    editorconfigIndentation: {
+    indentation: {
       message: 'Indentation',
       type: 'list',
       choices: ['2 spaces', '4 spaces', 'tabs'],

--- a/sao.js
+++ b/sao.js
@@ -115,7 +115,7 @@ module.exports = {
       }
     },
     trimWhitespaceMarkdown: {
-      message: 'Trim trailing whitespace in markdown files?',
+      message: 'Trim trailing whitespace in markdown files',
       type: 'confirm',
       default: true
     },

--- a/sao.js
+++ b/sao.js
@@ -131,6 +131,7 @@ module.exports = {
     // Because when it's published to npm
     // `.gitignore` file will be ignored!
     gitignore: '.gitignore',
+    example: 'example.js',
     README: 'README.md',
     package: 'package.json'
   },

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -1,9 +1,13 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
+<% if (editorconfigIndentation === '2 spaces') { %>indent_style = space
+indent_size = 2<% } else if (editorconfigIndentation === '4 spaces') { %>indent_style = space
+indent_size = 4<% } else if (editorconfigIndentation === 'tabs') { %>indent_style = tab<% } %>
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline = true<% if (!trimWhitespaceMarkdown) { %>
+
+[*.md]
+trim_trailing_whitespace = false<% } %>

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -1,9 +1,9 @@
 root = true
 
 [*]
-<% if (editorconfigIndentation === '2 spaces') { %>indent_style = space
-indent_size = 2<% } else if (editorconfigIndentation === '4 spaces') { %>indent_style = space
-indent_size = 4<% } else if (editorconfigIndentation === 'tabs') { %>indent_style = tab<% } %>
+<% if (indentation === '2 spaces') { %>indent_style = space
+indent_size = 2<% } else if (indentation === '4 spaces') { %>indent_style = space
+indent_size = 4<% } else if (indentation === 'tabs') { %>indent_style = tab<% } %>
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/template/package
+++ b/template/package
@@ -86,8 +86,10 @@
       "camelcase": "off",
       "no-warning-comments": "off"
     },<% if (indentation === '2 spaces') { %>
-    "space": true,<% } else if (indentation === '4 spaces') { %>
-    "space": 4,<% } %>
+    "space": true,
+    "tabWidth": 2,<% } else if (indentation === '4 spaces') { %>
+    "space": 4,
+    "tabWidth": 4,<% } %>
     "ignores": ["example.js"]
   }
 }

--- a/template/package
+++ b/template/package
@@ -85,7 +85,9 @@
       "capitalized-comments": "off",
       "camelcase": "off",
       "no-warning-comments": "off"
-    },
-    "space": true
+    },<% if (indentation === '2 spaces') { %>
+    "space": true,<% } else if (indentation === '4 spaces') { %>
+    "space": 4,<% } %>
+    "ignores": ["example.js"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4279,7 +4279,7 @@ remark-heading-gap@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remark-heading-gap/-/remark-heading-gap-3.0.0.tgz#f52ac47a27995ef3248a59eb7544b5620b4736a6"
 
-"remark-license@github:niftylettuce/remark-license":
+remark-license@niftylettuce/remark-license:
   version "4.0.1"
   resolved "https://codeload.github.com/niftylettuce/remark-license/tar.gz/17ecb8f64f8f6082414d14f9267a12764e6ddbfb"
   dependencies:


### PR DESCRIPTION
Continuation of #8. Adds configuration options to choose `2 spaces`, `4 spaces`, or `tabs` for indentation, and allows people to specify if they want to trim whitespace from markdown files.