### PR TITLE
Remove `private` field trailing whitespace

### DIFF
--- a/sao.js
+++ b/sao.js
@@ -114,8 +114,8 @@ module.exports = {
       },
       validate: val => {
         return isURL(val) &&
-        val.indexOf('https://github.com/') === 0 &&
-        val.lastIndexOf('/') !== val.length - 1
+          val.indexOf('https://github.com/') === 0 &&
+          val.lastIndexOf('/') !== val.length - 1
           ? true
           : 'Please include a valid GitHub.com URL without a trailing slash';
       }

--- a/template/package
+++ b/template/package
@@ -1,6 +1,6 @@
 {
   "name": "<%- name %>",
-  <% if (!public) { %>"private": true, <% } %>
+  <% if (!public) { %>"private": true,<% } %>
   "description": "<%- description %>",
   "version": "<%- version %>",
   "author": "<%- author %> <<%- email %>> (<%- website%>)",


### PR DESCRIPTION
Noticed a trailing whitespace after the `private` field after generating a private project. Also lint issues were failing the build. 

Great project by the way!