### PR TITLE
Choose between standard and prettier (#29)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "auto-bind": "^1.1.0",
     "cac": "^4.2.4",
     "camelcase": "^4.1.0",
+    "execa": "^0.8.0",
     "github-username": "^4.1.0",
     "github-username-regex": "^1.0.0",
     "global": "^4.3.2",

--- a/sao.js
+++ b/sao.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const { spawn } = require('child_process');
 
 const githubUsernameRegex = require('github-username-regex');
 // const opn = require('opn');
@@ -122,6 +123,13 @@ module.exports = {
           : 'Please include a valid GitHub.com URL without a trailing slash';
       }
     },
+    eslint: {
+      message: 'Choose the eslint config',
+      choices: ['standard', 'prettier'],
+      type: 'list',
+      default: 'standard',
+      store: true
+    },
     keywords: {
       message:
         'Write some keywords related to your project (comma/space separated)',
@@ -188,6 +196,13 @@ module.exports = {
       ctx.log.error(err.message);
     }
     */
+
+    // Format code according to eslint configuration
+    const linter = ctx.answers.eslint === 'standard' ? 'standard' : 'xo';
+    await spawn(`./node_modules/.bin/${linter}`, ['--fix'], {
+      cwd: ctx.folderPath,
+      stdio: 'inherit'
+    });
 
     ctx.showTip();
   }

--- a/sao.js
+++ b/sao.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const { spawn } = require('child_process');
+const execa = require('execa');
 
 const githubUsernameRegex = require('github-username-regex');
 // const opn = require('opn');
@@ -199,7 +199,7 @@ module.exports = {
 
     // Format code according to eslint configuration
     const linter = ctx.answers.eslint === 'standard' ? 'standard' : 'xo';
-    await spawn(`./node_modules/.bin/${linter}`, ['--fix'], {
+    await execa(`./node_modules/.bin/${linter}`, ['--fix'], {
       cwd: ctx.folderPath,
       stdio: 'inherit'
     });

--- a/template/package
+++ b/template/package
@@ -20,15 +20,15 @@
     "codecov": "^2.3.0",
     "cross-env": "^5.0.5",
     "eslint": "^4.5.0",
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-plugin-prettier": "^2.2.0",
+    "eslint-config-<%- eslint %>": "latest",
+    "eslint-plugin-<%- eslint %>": "latest",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.4",
     "nyc": "^11.1.0",
     "prettier": "^1.6.1",
     "remark-cli": "^4.0.0",
     "remark-preset-github": "^0.0.6",
-    "xo": "^0.19.0"
+    <%- eslint === 'standard' ? `"standard"`: `"xo"` %>: "latest"
   },
   "engines": {
     "node": ">=8.3"
@@ -58,13 +58,7 @@
     "type": "git",
     "url": "<%- repo %>"
   },
-  "scripts": {
-    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "lint": "xo && remark . -qfo",
-    "precommit": "lint-staged && npm test",
-    "test": "npm run lint && npm run test-coverage",
-    "test-coverage": "cross-env NODE_ENV=test nyc ava"
-  },
+  <% if (eslint === 'prettier') { %>
   "xo": {
     "extends": "prettier",
     "plugins": ["prettier"],
@@ -92,5 +86,17 @@
       "no-warning-comments": "off"
     },
     "space": true
+  },
+  <% } %>
+  "scripts": {
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    <% if (eslint === 'prettier') { %>
+    "lint": "xo && remark . -qfo",
+    <% } else { %>
+    "lint": "standard && remark . -qfo",
+    <% } %>
+    "precommit": "lint-staged && npm test",
+    "test": "npm run lint && npm run test-coverage",
+    "test-coverage": "cross-env NODE_ENV=test nyc ava"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4341,7 +4341,7 @@ remark-heading-gap@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remark-heading-gap/-/remark-heading-gap-3.0.0.tgz#f52ac47a27995ef3248a59eb7544b5620b4736a6"
 
-"remark-license@github:niftylettuce/remark-license":
+remark-license@niftylettuce/remark-license:
   version "4.0.1"
   resolved "https://codeload.github.com/niftylettuce/remark-license/tar.gz/17ecb8f64f8f6082414d14f9267a12764e6ddbfb"
   dependencies:


### PR DESCRIPTION
I got it working both with `standard` and `xo/prettier`. I had to do a manual `--fix` in sao's `post` to format the code depending on the linter.

Also, I think we would have some conflicts with https://github.com/lassjs/lass/pull/9, as both do similar things.