### PR TITLE
Consolidate prettier configuration into one place

### DIFF
--- a/template/package
+++ b/template/package
@@ -38,7 +38,7 @@
   "license": "MIT",
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx,css,less,scss,json,graphql}": [
-      "prettier --write --single-quote --trailing-comma none",
+      "prettier --write",
       "git add"
     ],
     "*.md": ["remark . -qfo", "git add"]
@@ -58,6 +58,11 @@
     "type": "git",
     "url": "<%- repo %>"
   },
+  "prettier": {
+    "singleQuote": true,
+    "bracketSpacing": true,
+    "trailingComma": "none"
+  },
   <% if (eslint === 'prettier') { %>
   "xo": {
     "extends": "prettier",
@@ -66,14 +71,7 @@
       "sourceType": "script"
     },
     "rules": {
-      "prettier/prettier": [
-        "error",
-        {
-          "singleQuote": true,
-          "bracketSpacing": true,
-          "trailingComma": "none"
-        }
-      ],
+      "prettier/prettier": "error",
       "max-len": [
         "error",
         {


### PR DESCRIPTION
Prettier configuration was duplicated between the `lint-staged` and `xo` blocks in package.json. I discovered this because I changed the value for `trailingComma` in my `xo` config, and I wasn't able to commit because my `lint-staged` command kept removing the commas.

This PR puts all the prettier configuration in one place in package.json