### PR TITLE
fix: run scripts with chosen package manager

### DIFF
--- a/template/package
+++ b/template/package
@@ -86,8 +86,8 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "lint": "xo && remark . -qfo",
-    "test": "npm run lint && npm run ava",
-    "test-coverage": "npm run lint && npm run nyc",
+    "test": "<%- pm %> run lint && <%- pm %> run ava",
+    "test-coverage": "<%- pm %> run lint && <%- pm %> run nyc",
     "ava": "cross-env NODE_ENV=test ava",
     "nyc": "cross-env NODE_ENV=test nyc ava"
   }


### PR DESCRIPTION
Fixes some warnings that can happen when mixing yarn and npm:
<img width="1279" alt="Screen Shot 2020-01-23 at 9 37 46 AM" src="https://user-images.githubusercontent.com/16724951/72993954-42b0f880-3dc4-11ea-9899-3047af97040d.png">
