### PR TITLE
fix: pin remark-cli to commonjs form

### DIFF
--- a/template/package
+++ b/template/package
@@ -46,7 +46,7 @@
     "husky": "latest",
     "lint-staged": "latest",
     "nyc": "latest",
-    "remark-cli": "latest",
+    "remark-cli": "^9.0.0",
     "remark-preset-github": "latest",
     <% if (linter==='xo') {%>
     "eslint-config-xo-lass": "latest",


### PR DESCRIPTION
Pinning `remark-cli` to commonjs form as 10.x.x adds esmodule support and will show the below on new lass projects

```
> remark . -qfo

README.md
  1:1  error  Error: Cannot parse file `.remarkrc`
Cannot import `node_modules/remark-preset-github/index.js`
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/shaunwarman/Development/Source/side/xxx/node_modules/to-vfile/index.js from /Users/shaunwarman/Development/Source/side/xxx/node_modules/remark-contributors/index.js not supported.
Instead change the require of /Users/shaunwarman/Development/Source/side/xxx/node_modules/to-vfile/index.js in /Users/shaunwarman/Development/Source/side/xxx/node_modules/remark-contributors/index.js to a dynamic import() which is available in all CommonJS modules
```